### PR TITLE
md2pdf wrapper

### DIFF
--- a/md2pdf/Dockerfile
+++ b/md2pdf/Dockerfile
@@ -1,0 +1,52 @@
+FROM node:latest
+
+RUN apt update && \
+    apt-get install -y \
+        pdftk \
+        ca-certificates \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatk1.0-0 \
+        libc6 \
+        libcairo2 \
+        libcups2 \
+        libdbus-1-3 \
+        libexpat1 \
+        libfontconfig1 \
+        libgbm1 \
+        libgcc1 \
+        libglib2.0-0 \
+        libgtk-3-0 \
+        libnspr4 \
+        libnss3 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libstdc++6 \
+        libx11-6 \
+        libx11-xcb1 \
+        libxcb1 \
+        libxcomposite1 \
+        libxcursor1 \
+        libxdamage1 \
+        libxext6 \
+        libxfixes3 \
+        libxi6 \
+        libxrandr2 \
+        libxrender1 \
+        libxss1 \
+        libxtst6 \
+        lsb-release \
+        wget \
+        xdg-utils && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN npm install md-to-pdf -g --unsafe-perm
+
+COPY ./md2pdf-do.bash /usr/local/bin/md2pdf-do
+RUN chmod 0755 /usr/local/bin/md2pdf-do && \
+    chown root:root /usr/local/bin/md2pdf-do
+
+ENTRYPOINT [ "md2pdf-do" ]

--- a/md2pdf/README.md
+++ b/md2pdf/README.md
@@ -1,0 +1,9 @@
+## Docker wrapper for md-to-pdf and pdftk
+A docker wrapper for md-to-pdf and pdftk to generate and merge a single PDF 
+document from given markdown files.
+
+### Build
+`$ docker build -t md2pdf-do .`
+
+### Run
+`$ docker run --rm -v /path/to/:/path/to/ md2pdf-do -o /path/to/content.pdf /path/to/input.1.md /path/to/input.2.md`

--- a/md2pdf/md2pdf-do.bash
+++ b/md2pdf/md2pdf-do.bash
@@ -18,7 +18,7 @@ usage()
 
 where:
     -h  show this help text
-    -o  output target for the converted PDF; defaults to index.html" 
+    -o  output target for the converted PDF; defaults to output.pdf" 
     exit
 }
 

--- a/md2pdf/md2pdf-do.bash
+++ b/md2pdf/md2pdf-do.bash
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+FATAL_EXIT=1
+BASE_DIR=/tmp
+BUILD_DIR=`mktemp -d`
+
+MD2PDF_CLI=`command -v md2pdf`
+PDFTK_CLI=`command -v pdftk`
+
+log()
+{
+    echo "$(date +"%F %T"): $*"
+}
+
+usage()
+{
+    echo -e "$(basename "$0") [-h] [-o <output>] <input pdf>... -- program to start a md2pdf node
+
+where:
+    -h  show this help text
+    -o  output target for the converted PDF; defaults to index.html" 
+    exit
+}
+
+# START #
+
+arg_index=1 # start at 1 for the basename
+output="output.pdf"
+
+while getopts "ho:" opt; do
+    case "$opt" in
+    [h?]) usage
+        ;;
+    o) output=$OPTARG
+        arg_index=$((arg_index+2)) # add 2 for flag and argument
+        ;;
+    esac
+done
+
+input=${@:$arg_index}
+md_args=()
+pdf_args=()
+
+for i in ${input}
+do
+    if [ ! -f "$i" ]; then
+        echo "'${input}': No such file or directory" >&2
+        exit $FATAL_EXIT
+    fi
+    filename=`basename -- "$i"`
+    md_args+=(${BUILD_DIR}/${filename})
+    pdf_args+=(${BUILD_DIR}/${filename%.*}.pdf)
+done
+
+dir=`cd "$(dirname $output)"; pwd`
+if [ ${#dir} -gt 0 ] && [ ! -d "$dir" ]; then
+    echo "'${dir}': No such directory" >&2
+    exit $FATAL_EXIT
+fi
+
+mkdir -p $BUILD_DIR && \
+cp ${input[@]} $BUILD_DIR && \
+$MD2PDF_CLI ${md_args[@]} \
+    --basedir $BASE_DIR \
+    --launch-options '{ "args": ["--no-sandbox"] }' && \
+$PDFTK_CLI ${pdf_args[@]} output $output


### PR DESCRIPTION
Adds a new Dockerfile that wraps md-to-pdf and pdftk to generate PDF documents from Markdown files, and merge them into a single document.